### PR TITLE
feat: Implement diffing algorithm for MapTemplates

### DIFF
--- a/src/main/java/xyz/nucleoid/map_templates/MapTemplateMetadata.java
+++ b/src/main/java/xyz/nucleoid/map_templates/MapTemplateMetadata.java
@@ -116,4 +116,12 @@ public final class MapTemplateMetadata {
     public NbtCompound getData() {
         return this.data;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MapTemplateMetadata)) return false;
+
+        return this.data.equals(((MapTemplateMetadata) o).data) && this.regions.equals(((MapTemplateMetadata) o).regions);
+    }
 }

--- a/src/main/java/xyz/nucleoid/map_templates/TemplateRegion.java
+++ b/src/main/java/xyz/nucleoid/map_templates/TemplateRegion.java
@@ -55,4 +55,11 @@ public final class TemplateRegion {
     public TemplateRegion copy() {
         return new TemplateRegion(this.marker, this.bounds, this.data != null ? this.data.copy() : null);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TemplateRegion other)) return false;
+        return this.data.equals(other.data) && this.marker.equals(other.marker) && this.bounds.equals(other.bounds);
+    }
 }


### PR DESCRIPTION
This PR implements a very coarse diffing algorithm for map templates. It is intended to be used with https://github.com/NucleoidMC/plasmid/pull/293 as such:

The functionality offered is therefore pretty much the bare minimum to support that use case.
```java
        if (newTemplate.diff(oldTemplate).needsRegeneration()) {
            gameSpace.getWorlds().regenerate(world, new TemplateChunkGenerator(server, newTemplate), newTemplate.getBounds().union(oldTemplate.getBounds()));
        }
```

The diffing algorithm uses the BLAKE3 hash function internally to compare `MapChunk`s.

It takes around 100ms to hash a map that takes 400ms to load (based on siege:jungle).