### PR TITLE
Update mod to Minecraft 1.21

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-minecraft_version=1.20.6
-yarn_mappings=1.20.6+build.1
+minecraft_version=1.21
+yarn_mappings=1.21+build.7
 loader_version=0.15.11
 
 # Mod Properties

--- a/src/main/java/xyz/nucleoid/map_templates/MapTemplateSerializer.java
+++ b/src/main/java/xyz/nucleoid/map_templates/MapTemplateSerializer.java
@@ -151,9 +151,12 @@ public final class MapTemplateSerializer {
         template.bounds = BlockBounds.deserialize(root.getCompound("bounds"));
         metadata.data = root.getCompound("data");
 
-        var biomeId = root.getString("biome");
-        if (!Strings.isNullOrEmpty(biomeId)) {
-            template.biome = RegistryKey.of(RegistryKeys.BIOME, new Identifier(biomeId));
+        var biomeIdString = root.getString("biome");
+        if (!Strings.isNullOrEmpty(biomeIdString)) {
+            var biomeId = Identifier.tryParse(biomeIdString);
+            if (biomeId != null) {
+                template.biome = RegistryKey.of(RegistryKeys.BIOME, biomeId);
+            }
         }
     }
 
@@ -214,6 +217,6 @@ public final class MapTemplateSerializer {
     }
 
     public static Identifier getResourcePathFor(Identifier identifier) {
-        return new Identifier(identifier.getNamespace(), "map_templates/" + identifier.getPath() + ".nbt");
+        return Identifier.of(identifier.getNamespace(), "map_templates/" + identifier.getPath() + ".nbt");
     }
 }

--- a/src/main/java/xyz/nucleoid/map_templates/MapTemplateSerializer.java
+++ b/src/main/java/xyz/nucleoid/map_templates/MapTemplateSerializer.java
@@ -217,6 +217,6 @@ public final class MapTemplateSerializer {
     }
 
     public static Identifier getResourcePathFor(Identifier identifier) {
-        return Identifier.of(identifier.getNamespace(), "map_templates/" + identifier.getPath() + ".nbt");
+        return identifier.withPath(path -> "map_templates/" + path + ".nbt");
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,7 +18,7 @@
     }
   },
   "depends": {
-    "minecraft": ">=1.21-alpha.24.21.a",
+    "minecraft": ">=1.20.5-alpha.24.14.a",
     "java": ">=21"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,7 +18,7 @@
     }
   },
   "depends": {
-    "minecraft": ">=1.20.5-alpha.24.14.a",
+    "minecraft": ">=1.21-alpha.24.21.a",
     "java": ">=21"
   }
 }


### PR DESCRIPTION
By using identifier path composition methods, compatibility with both Minecraft 1.20.6 and 1.21 can be achieved. This pull request currently targets the `1.20.6` branch, but I'm unsure if a new branch would be created in this scenario.

Note that this pull request also introduces a small behavioral change: rather than throwing an exception, a map template with an invalid biome ID will fall back to the default void biome.

Minecraft 1.21 renames data pack directories to be singular. This change could be followed for the map templates directory as part of version 0.2.0's breaking changes.