### PR TITLE
Make the directory name for map templates in data packs singular

### DIFF
--- a/src/main/java/xyz/nucleoid/map_templates/MapTemplateSerializer.java
+++ b/src/main/java/xyz/nucleoid/map_templates/MapTemplateSerializer.java
@@ -217,6 +217,6 @@ public final class MapTemplateSerializer {
     }
 
     public static Identifier getResourcePathFor(Identifier identifier) {
-        return identifier.withPath(path -> "map_templates/" + path + ".nbt");
+        return identifier.withPath(path -> "map_template/" + path + ".nbt");
     }
 }


### PR DESCRIPTION
This pull request introduces a breaking change to data pack loading: map templates are now loaded from `data/<namespace>/map_template/<path>.nbt` rather than `data/<namespace>/map_templates/<path>.nbt`, matching a similar change in Minecraft 1.21 for other data pack contents.