### PR TITLE
Validate the minimum position of block bounds being smaller than the maximum position

### DIFF
--- a/src/main/java/xyz/nucleoid/map_templates/BlockBounds.java
+++ b/src/main/java/xyz/nucleoid/map_templates/BlockBounds.java
@@ -31,6 +31,18 @@ public record BlockBounds(BlockPos min, BlockPos max) implements Iterable<BlockP
             ).apply(instance, BlockBounds::new)
     );
 
+    public BlockBounds {
+        if (min.getX() > max.getX() || min.getY() > max.getY() || min.getZ() > max.getZ()) {
+            String message = String.format(
+                    "Minimum position (%d, %d, %d) of bounds must be smaller than maximum position (%d, %d, %d)",
+                    min.getX(), min.getY(), min.getZ(),
+                    max.getX(), max.getY(), max.getZ()
+            );
+
+            throw new IllegalArgumentException(message);
+        }
+    }
+
     public static BlockBounds of(BlockPos a, BlockPos b) {
         return new BlockBounds(min(a, b), max(a, b));
     }


### PR DESCRIPTION
This pull request introduces new validation for the `BlockBounds` constructor to ensure that the minimum and maximum positions are valid. When the minimum position is greater than the maximum position, some methods would work incorrectly; for example, block bounds from (3, 3, 3) to (-3, -3, 3) would never be considered to contain the position (0, 0, 0).

Previously, the `BlockBounds` constructor was private, meaning that API consumers could not create invalid block bounds. This issue was introduced with #4, which made the `BlockBounds` class a record with constructor that must be public.

This pull request technically introduces a breaking change, even though the current behavior can lead to clearly undesirable results.